### PR TITLE
Remove registerWith which has been long deprecated.

### DIFF
--- a/android/src/main/java/in/jvapps/disable_battery_optimization/DisableBatteryOptimizationPlugin.java
+++ b/android/src/main/java/in/jvapps/disable_battery_optimization/DisableBatteryOptimizationPlugin.java
@@ -44,20 +44,6 @@ public class DisableBatteryOptimizationPlugin implements FlutterPlugin, Activity
     private String manBatteryMessage;
 
 
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(PluginRegistry.Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-        channel.setMethodCallHandler(new DisableBatteryOptimizationPlugin(registrar.activity(), registrar.activeContext()));
-    }
-
     private DisableBatteryOptimizationPlugin(Activity activity, Context context) {
         if (activity != null)
             mActivity = activity;


### PR DESCRIPTION
This was removed from Flutter 3.29 so this method causes the plugin to no longer build.